### PR TITLE
Update .gitignore to add macOS OS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ node_modules
 # OS
 .DS_Store
 Thumbs.db
+.Spotlight_V100
+.Trashes
+**/._*
+._*
 
 # Env
 .env


### PR DESCRIPTION
Added the following in `.gitignore` for macOS OS files:
```
.Spotlight_V100
.Trashes
**/._*
._*
```
# Edit
* `.Spotlight_V100` should be `._Spotlight_V100` (note the first underscore)
* I didn't edit the pull request commit because I couldn't figure out how (if you know how, please reply)